### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/foundry-ci.yml
+++ b/.github/workflows/foundry-ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Foundry CI
 
 on:

--- a/.github/workflows/foundry-ci.yml
+++ b/.github/workflows/foundry-ci.yml
@@ -1,6 +1,8 @@
 permissions:
   contents: read
 name: Foundry CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/taproots-wisdom/torc/security/code-scanning/1](https://github.com/taproots-wisdom/torc/security/code-scanning/1)

To fix this problem, add a `permissions` block at the root of the workflow YAML—or, alternatively, at the job level—to specify the minimum required privileges. The minimal and recommended permission is `contents: read`, which covers the needs of this workflow: checking out code and reading repo content. No steps in the job modify repository contents or use advanced GitHub APIs that require extra permissions. The `permissions` field should be added after the `name:` and before the `on:` block for global workflow effect and clarity. No other changes, imports, or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
