### PR TITLE
Potential fix for code scanning alert no. 2: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/foundry-ci.yml
+++ b/.github/workflows/foundry-ci.yml
@@ -32,7 +32,6 @@ jobs:
           forge install  foundry-rs/forge-std@v1.10.0
       - name: 'Create env file'
         run: |
-          echo "testing secrets: ${{ toJson(secrets) }}"
           echo "MAINNET_RPC_URL=${{ secrets.MAINNET_RPC_URL }}" >> .env
           echo "TOKEN_OWNER_PK=${{ secrets.TOKEN_OWNER_PK }}" >> .env
           echo "WETH=${{ secrets.WETH }}" >> .env


### PR DESCRIPTION
Potential fix for [https://github.com/taproots-wisdom/torc/security/code-scanning/2](https://github.com/taproots-wisdom/torc/security/code-scanning/2)

To fix this problem, we need to remove or replace any reference to `toJson(secrets)` in the workflow. Instead of serializing and echoing all available secrets, we should only expose specifically required secrets, and only if absolutely necessary. In this context, the problematic line (`echo "testing secrets: ${{ toJson(secrets) }}"`) can be safely removed as it serves no critical functional role and exposes secrets to the logs—a severe security risk.

**Best fix:**  
- Delete or comment out line 35: `echo "testing secrets: ${{ toJson(secrets) }}"`.
- Do not otherwise modify how individual secrets are written to the `.env` file (lines 36–48), as these lines already target only specific secrets that are in-use.

No additional methods, imports, or definitions are needed for this change. Only the workflow file itself is edited (single-line deletion/modification).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
